### PR TITLE
Refactor shared parsing helpers and align core modules with Python conventions

### DIFF
--- a/check_data.py
+++ b/check_data.py
@@ -5,18 +5,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-
-def to_int(value: Any, default: int = 0) -> int:
-    """숫자/문자 섞인 값을 안전하게 int로 변환."""
-    try:
-        if value in (None, "", "-", " "):
-            return default
-        return int(value)
-    except Exception:
-        try:
-            return int(float(str(value)))
-        except Exception:
-            return default
+from common_utils import to_int
 
 
 def ip_str_to_outs(ip: Any) -> int:

--- a/common_utils.py
+++ b/common_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+EMPTY_VALUES = (None, "", "-", " ")
+
+
+def first_non_empty(*values: Any) -> Any:
+    """비어 있지 않은 첫 번째 값을 반환한다."""
+    for value in values:
+        if value not in (None, "", [], {}):
+            return value
+    return None
+
+
+def to_int(value: Any, default: int | None = 0) -> int | None:
+    """숫자/문자 섞인 값을 안전하게 int로 변환한다."""
+    if value in EMPTY_VALUES:
+        return default
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        try:
+            return int(float(str(value)))
+        except (TypeError, ValueError):
+            return default

--- a/graphic_interface.py
+++ b/graphic_interface.py
@@ -1,10 +1,18 @@
-import os, json, threading, datetime, queue, traceback, calendar
+import calendar
+import datetime
+import json
+import os
+import queue
+import threading
+import traceback
+
 import dearpygui.dearpygui as dpg
-from selenium.common.exceptions import TimeoutException
+
 from web_interface import Scrapper
 import check_data
 
-class kbo_naver_scrapper_gui:
+
+class KboNaverScrapperGUI:
     def __init__(self):
         # 공통 상태
         self.msg_q = queue.Queue()
@@ -564,6 +572,10 @@ class kbo_naver_scrapper_gui:
     def run(self):
         self.build_ui()
 
+
+kbo_naver_scrapper_gui = KboNaverScrapperGUI
+
+
 if __name__ == "__main__":
-    gui = kbo_naver_scrapper_gui()
+    gui = KboNaverScrapperGUI()
     gui.run()

--- a/postgres_loader.py
+++ b/postgres_loader.py
@@ -8,29 +8,12 @@ from typing import Any, Iterable
 import psycopg
 from psycopg.types.json import Json
 
-
-def _first_non_empty(*values: Any) -> Any:
-    for value in values:
-        if value not in (None, "", [], {}):
-            return value
-    return None
-
-
-def _safe_int(value: Any, default: int | None = None) -> int | None:
-    if value in (None, "", "-"):
-        return default
-    try:
-        return int(value)
-    except Exception:
-        try:
-            return int(float(str(value)))
-        except Exception:
-            return default
+from common_utils import first_non_empty, to_int
 
 
 def _extract_game_meta(lineup: dict[str, Any]) -> dict[str, Any]:
     info = lineup.get("game_info") or {}
-    raw_date = _first_non_empty(info.get("gdate"), info.get("gameDate"), info.get("date"))
+    raw_date = first_non_empty(info.get("gdate"), info.get("gameDate"), info.get("date"))
     parsed_date = None
     if raw_date:
         try:
@@ -39,11 +22,11 @@ def _extract_game_meta(lineup: dict[str, Any]) -> dict[str, Any]:
             parsed_date = None
     return {
         "game_date": parsed_date,
-        "stadium": _first_non_empty(info.get("stadium"), info.get("stadiumName")),
-        "home_team_code": _first_non_empty(info.get("hCode"), info.get("homeTeamCode"), info.get("hcode")),
-        "away_team_code": _first_non_empty(info.get("aCode"), info.get("awayTeamCode"), info.get("acode")),
-        "home_team_name": _first_non_empty(info.get("hName"), info.get("homeTeamName"), info.get("hFullName")),
-        "away_team_name": _first_non_empty(info.get("aName"), info.get("awayTeamName"), info.get("aFullName")),
+        "stadium": first_non_empty(info.get("stadium"), info.get("stadiumName")),
+        "home_team_code": first_non_empty(info.get("hCode"), info.get("homeTeamCode"), info.get("hcode")),
+        "away_team_code": first_non_empty(info.get("aCode"), info.get("awayTeamCode"), info.get("acode")),
+        "home_team_name": first_non_empty(info.get("hName"), info.get("homeTeamName"), info.get("hFullName")),
+        "away_team_name": first_non_empty(info.get("aName"), info.get("awayTeamName"), info.get("aFullName")),
     }
 
 
@@ -54,14 +37,14 @@ def _iter_players(game: dict[str, Any]) -> Iterable[dict[str, Any]]:
     for side in ("home", "away"):
         for section in ("starter", "bullpen", "candidate"):
             for row in lineup.get(f"{side}_{section}") or []:
-                player_id = str(_first_non_empty(row.get("playerCode"), row.get("pcode"), row.get("playerId")) or "")
+                player_id = str(first_non_empty(row.get("playerCode"), row.get("pcode"), row.get("playerId")) or "")
                 if not player_id:
                     continue
                 yield {
                     "player_id": player_id,
-                    "name": _first_non_empty(row.get("playerName"), row.get("name"), "UNKNOWN"),
-                    "throws": _first_non_empty(row.get("throwBat"), row.get("throws")),
-                    "bats": _first_non_empty(row.get("hitType"), row.get("bats")),
+                    "name": first_non_empty(row.get("playerName"), row.get("name"), "UNKNOWN"),
+                    "throws": first_non_empty(row.get("throwBat"), row.get("throws")),
+                    "bats": first_non_empty(row.get("hitType"), row.get("bats")),
                     "raw": row,
                 }
 
@@ -69,20 +52,20 @@ def _iter_players(game: dict[str, Any]) -> Iterable[dict[str, Any]]:
         boxscore = record.get(section) or {}
         for side in ("home", "away"):
             for row in boxscore.get(side) or []:
-                player_id = str(_first_non_empty(row.get(key), row.get("playerCode"), row.get("pcode")) or "")
+                player_id = str(first_non_empty(row.get(key), row.get("playerCode"), row.get("pcode")) or "")
                 if not player_id:
                     continue
                 yield {
                     "player_id": player_id,
-                    "name": _first_non_empty(row.get("name"), row.get("playerName"), "UNKNOWN"),
-                    "throws": _first_non_empty(row.get("hitType"), row.get("throws")),
-                    "bats": _first_non_empty(row.get("hitType"), row.get("bats")),
+                    "name": first_non_empty(row.get("name"), row.get("playerName"), "UNKNOWN"),
+                    "throws": first_non_empty(row.get("hitType"), row.get("throws")),
+                    "bats": first_non_empty(row.get("hitType"), row.get("bats")),
                     "raw": row,
                 }
 
 
 def _map_event_type(type_code: Any, text: str) -> tuple[str, str | None]:
-    code = _safe_int(type_code, -1)
+    code = to_int(type_code, -1)
     txt = text or ""
 
     if code in (1, 2, 3):
@@ -130,7 +113,7 @@ def _extract_events(relay: list[Any]) -> list[EventRow]:
         for half_block in inning_block or []:
             home_or_away = str(half_block.get("homeOrAway", ""))
             half = "T" if home_or_away == "0" else "B"
-            inning_no = _safe_int(_first_non_empty(half_block.get("inning"), half_block.get("inn")), inning_idx)
+            inning_no = to_int(first_non_empty(half_block.get("inning"), half_block.get("inn")), inning_idx)
 
             for item in half_block.get("textOptions") or []:
                 state = item.get("currentGameState") or {}
@@ -148,11 +131,15 @@ def _extract_events(relay: list[Any]) -> list[EventRow]:
                         raw=item,
                         batter_id=str(state.get("batter")) if state.get("batter") else None,
                         pitcher_id=str(state.get("pitcher")) if state.get("pitcher") else None,
-                        outs_before=_safe_int(_first_non_empty(state.get("outCount"), state.get("outs"))),
-                        balls_before=_safe_int(_first_non_empty(state.get("ballCount"), state.get("balls"))),
-                        strikes_before=_safe_int(_first_non_empty(state.get("strikeCount"), state.get("strikes"))),
-                        score_home_before=_safe_int(_first_non_empty(state.get("homeTeamScore"), state.get("homeScore"))),
-                        score_away_before=_safe_int(_first_non_empty(state.get("awayTeamScore"), state.get("awayScore"))),
+                        outs_before=to_int(first_non_empty(state.get("outCount"), state.get("outs")), None),
+                        balls_before=to_int(first_non_empty(state.get("ballCount"), state.get("balls")), None),
+                        strikes_before=to_int(first_non_empty(state.get("strikeCount"), state.get("strikes")), None),
+                        score_home_before=to_int(
+                            first_non_empty(state.get("homeTeamScore"), state.get("homeScore")), None
+                        ),
+                        score_away_before=to_int(
+                            first_non_empty(state.get("awayTeamScore"), state.get("awayScore")), None
+                        ),
                     )
                 )
                 seq_no += 1

--- a/web_interface.py
+++ b/web_interface.py
@@ -1,23 +1,31 @@
-import datetime, json, time, os, re
+import datetime
+import json
+import os
 from seleniumwire import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.edge.options import Options as EdgeOptions
 from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.common.exceptions import TimeoutException
-from selenium.common.exceptions import StaleElementReferenceException
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
 
 # Selenium을 이용해 스크래핑을 수행하는 클래스
 class Scrapper:
-    def __init__(self, wait = 10, path = 'games'):
+    def __init__(self, wait=10, path="games"):
         edge_options = EdgeOptions()
         edge_options.add_argument("--no-sandbox")
         edge_options.add_argument("--headless=new")
         edge_options.add_argument('user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
                                   'AppleWebKit/537.36 (KHTML, like Gecko) '
                                   'Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0')
-        sw_options = {'exclude_hosts': ['mtalk.google.com', 'fcm.googleapis.com', 'clients.google.com', 'clients2.google.com']}
+        sw_options = {
+            "exclude_hosts": [
+                "mtalk.google.com",
+                "fcm.googleapis.com",
+                "clients.google.com",
+                "clients2.google.com",
+            ]
+        }
         self.driver = webdriver.Edge(options=edge_options, seleniumwire_options=sw_options)
 
         self.driver.implicitly_wait(wait)
@@ -38,8 +46,12 @@ class Scrapper:
         ActionChains(self.driver).move_to_element(button).click(button).perform()
 
     # CSS_SELECTOR로 요소 찾기
-    def find_element_CSSS(self, parent, query):
+    def find_element_css(self, parent, query):
         return parent.find_element(By.CSS_SELECTOR, query)
+
+    # backward compatibility
+    def find_element_CSSS(self, parent, query):
+        return self.find_element_css(parent, query)
     
     # 대기용 함수
     def wait_present(self, css, timeout = None, root = None, min_count = 1, visible = True, fresh = True):
@@ -138,13 +150,13 @@ class Scrapper:
         
         for _ in range(retry):
             try:
-                tab_list = self.find_element_CSSS(self.driver, tab_css)
+                tab_list = self.find_element_css(self.driver, tab_css)
                 tab_buttons = tab_list.find_elements(By.CSS_SELECTOR, 'button')
         
                 tab_button_dict = dict()
                 
                 for btn in tab_buttons:
-                    text = self.find_element_CSSS(btn, 'span[class^="GameTab_text"]').text
+                    text = self.find_element_css(btn, 'span[class^="GameTab_text"]').text
                     tab_button_dict[text] = btn
                 
                 if tab_button_dict:
@@ -155,9 +167,9 @@ class Scrapper:
 
     # 중계 페이지 내에서 이닝 버튼 찾기
     def find_inning_button(self):
-        main_section = self.find_element_CSSS(self.driver, 'div[class^="Home_main_section"]')
-        game_panel = self.find_element_CSSS(main_section, 'section[class^="Home_game_panel"]')
-        tab_list = self.find_element_CSSS(game_panel, 'div[class^="SetTab_tab_list"]')
+        main_section = self.find_element_css(self.driver, 'div[class^="Home_main_section"]')
+        game_panel = self.find_element_css(main_section, 'section[class^="Home_game_panel"]')
+        tab_list = self.find_element_css(game_panel, 'div[class^="SetTab_tab_list"]')
         inning_buttons = tab_list.find_elements(By.CSS_SELECTOR, 'button')
 
         inning_buttons[:] = [btn for btn in inning_buttons if btn.is_enabled()]
@@ -245,7 +257,7 @@ class Scrapper:
         self.wait_present('div[class^="CalendarDate_calendar_tab_wrap"]')
 
         css_tree = 'div[class^="Home_container"] div[class^="CalendarDate_schedule_date_area"] div[class^="CalendarDate_calendar_tab_wrap"]'
-        date_tab = self.find_element_CSSS(self.driver, css_tree)
+        date_tab = self.find_element_css(self.driver, css_tree)
         date_buttons_em = date_tab.find_elements(By.CSS_SELECTOR, 'button:not([disabled]) em')
 
         activated_dates = []
@@ -292,12 +304,12 @@ class Scrapper:
         except TimeoutException:
             # 경기 없음 or 무한 로딩 -> 건너뜀
             return []
-        main_section = self.find_element_CSSS(self.driver, 'div[class^="Home_container"]')
+        main_section = self.find_element_css(self.driver, 'div[class^="Home_container"]')
         match_group = main_section.find_elements(By.CSS_SELECTOR, 'div[class^="ScheduleAllType_match_list_group"]')
 
         for grp in match_group:
-            a = self.find_element_CSSS(grp, 'div[class^="ScheduleAllType_title_area"]')
-            em = self.find_element_CSSS(a, 'em')
+            a = self.find_element_css(grp, 'div[class^="ScheduleAllType_title_area"]')
+            em = self.find_element_css(a, "em")
             if em.text == "KBO리그":
                 target_group = grp
                 break
@@ -310,16 +322,16 @@ class Scrapper:
         match_urls = []    
         matches = target_group.find_elements(By.CSS_SELECTOR, 'li[class^="MatchBox_match_item"]')
         for match in matches:
-            match_status = self.find_element_CSSS(match, 'em[class^=MatchBox_status]')
+            match_status = self.find_element_css(match, "em[class^=MatchBox_status]")
             if match_status.text == "종료":
-                match_urls.append(self.find_element_CSSS(match, 'a[class^="MatchBox_link"]').get_attribute('href'))
+                match_urls.append(self.find_element_css(match, 'a[class^="MatchBox_link"]').get_attribute("href"))
 
         return match_urls
     
     # 다음 달로 이동
     def goto_next_month(self):
         self.wait_present('button[class^="CalendarDate_button_next"]')
-        next_button = self.find_element_CSSS(self.driver, 'button[class^="CalendarDate_button_next"]')
+        next_button = self.find_element_css(self.driver, 'button[class^="CalendarDate_button_next"]')
 
         self.click(next_button)
 
@@ -327,7 +339,7 @@ class Scrapper:
 
     def get_current_month(self):
         self.wait_present('time[class^="CalendarDate_current_date"]')
-        current = self.find_element_CSSS(self.driver, 'time[class^="CalendarDate_current_date"]')
+        current = self.find_element_css(self.driver, 'time[class^="CalendarDate_current_date"]')
 
         month = current.get_attribute('datetime').split('-')[1]
         return int(month)


### PR DESCRIPTION
## Summary
- introduced `common_utils.py` and moved shared value-coercion helpers there
- removed duplicated integer parsing / non-empty value selection logic from `check_data.py` and `postgres_loader.py`
- improved naming/style in UI and scraper modules (split grouped imports, renamed GUI class to `KboNaverScrapperGUI` with backward-compatible alias)
- renamed CSS finder helper in `web_interface.py` to `find_element_css` and kept a compatibility wrapper (`find_element_CSSS`)

## Why
- reduces duplicated logic and keeps parsing behavior consistent across loaders/validators
- improves readability and maintainability with clearer naming and cleaner imports
- preserves compatibility for existing code paths while moving toward Pythonic conventions

## Validation
- `python -m compileall common_utils.py check_data.py postgres_loader.py web_interface.py graphic_interface.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6452c9c708324a01d38e131c115a0)