### PR TITLE
Unify status channels and add global notification panel with recent-error quick access

### DIFF
--- a/kbo_integrated_gui.py
+++ b/kbo_integrated_gui.py
@@ -32,12 +32,21 @@ class KBOIntegratedDPGApp:
         dpg.create_context()
 
         with dpg.window(tag="main_window", label="KBO DB Replay QA", width=self.default_viewport_w - 40, height=self.default_viewport_h - 60):
+            dpg.add_text("공통 DB 연결", color=(120, 180, 255))
+            with dpg.group(horizontal=True):
+                dpg.add_text("DSN")
+                dpg.add_input_text(tag="dsn_input", width=900, default_value=self.state.default_dsn)
+                dpg.add_button(label="DB 연결", callback=lambda: self.ingestion_tab.connect_db())
+            dpg.add_text("DB 상태", tag="status_text")
+            dpg.add_input_text(tag="status_detail_text", multiline=True, readonly=True, width=-1, height=90)
+            dpg.add_separator()
+
             with dpg.tab_bar(tag="main_tab_bar", callback=self.on_tab_change):
                 self.collection_tab.build(parent="main_tab_bar")
                 self.ingestion_tab.build(parent="main_tab_bar")
                 self.replay_tab.build(parent="main_tab_bar")
             dpg.add_separator()
-            dpg.add_text("전역 알림 패널")
+            dpg.add_text("전역 알림 패널", color=(120, 255, 160))
             dpg.add_input_text(tag="global_notification_text", multiline=True, readonly=True, width=-1, height=120)
             with dpg.group(horizontal=True):
                 dpg.add_button(label="최근 오류 다시 보기 (F8)", callback=lambda: self.state.show_recent_error())

--- a/kbo_integrated_gui.py
+++ b/kbo_integrated_gui.py
@@ -24,14 +24,36 @@ class KBOIntegratedDPGApp:
         if dpg.does_item_exist("main_window"):
             self.replay_tab.apply_responsive_layout()
 
+    def on_tab_change(self, sender, app_data):
+        if dpg.get_item_label(app_data):
+            self.state.set_active_tab(dpg.get_item_label(app_data))
+
     def build(self):
         dpg.create_context()
 
         with dpg.window(tag="main_window", label="KBO DB Replay QA", width=self.default_viewport_w - 40, height=self.default_viewport_h - 60):
-            with dpg.tab_bar(tag="main_tab_bar"):
+            with dpg.tab_bar(tag="main_tab_bar", callback=self.on_tab_change):
                 self.collection_tab.build(parent="main_tab_bar")
                 self.ingestion_tab.build(parent="main_tab_bar")
                 self.replay_tab.build(parent="main_tab_bar")
+            dpg.add_separator()
+            dpg.add_text("전역 알림 패널")
+            dpg.add_input_text(tag="global_notification_text", multiline=True, readonly=True, width=-1, height=120)
+            with dpg.group(horizontal=True):
+                dpg.add_button(label="최근 오류 다시 보기 (F8)", callback=lambda: self.state.show_recent_error())
+                dpg.add_button(label="오류 디버그 펼치기/접기", callback=lambda: self.state.toggle_error_detail())
+            dpg.add_text("최근 오류 없음", tag="recent_error_summary", color=(255, 150, 150))
+            with dpg.group(tag="error_detail_group", show=False):
+                dpg.add_input_text(tag="global_error_debug_text", multiline=True, readonly=True, width=-1, height=90)
+            dpg.add_separator()
+            with dpg.group(horizontal=True):
+                dpg.add_text("현재 탭: 데이터 수집", tag="global_status_current_tab")
+                dpg.add_text("최근 작업: 대기 중", tag="global_status_recent_task")
+                dpg.add_text("상태: 대기", tag="global_status_result", color=(180, 180, 180))
+                dpg.add_text("마지막 업데이트: -", tag="global_status_updated_at")
+
+        with dpg.handler_registry():
+            dpg.add_key_press_handler(key=dpg.mvKey_F8, callback=lambda: self.state.show_recent_error())
 
         dpg.create_viewport(title="KBO Replay QA (Graphics + Alerts)", width=self.default_viewport_w, height=self.default_viewport_h)
         dpg.setup_dearpygui()

--- a/kbo_integrated_gui.py
+++ b/kbo_integrated_gui.py
@@ -19,18 +19,36 @@ class KBOIntegratedDPGApp:
 
         self.default_viewport_w = 1440
         self.default_viewport_h = 940
+        self.db_window_expanded_h = 130
+        self.alert_window_expanded_h = 240
+        self.collapsed_h = 28
+
+    def layout_windows(self):
+        if not dpg.does_item_exist("main_window"):
+            return
+        vw = dpg.get_viewport_client_width()
+        vh = dpg.get_viewport_client_height()
+        margin = 10
+        gap = 10
+
+        db_cfg = dpg.get_item_configuration("global_db_window") if dpg.does_item_exist("global_db_window") else {}
+        alert_cfg = dpg.get_item_configuration("global_alert_window") if dpg.does_item_exist("global_alert_window") else {}
+        db_h = self.collapsed_h if db_cfg.get("collapsed") else self.db_window_expanded_h
+        alert_h = self.collapsed_h if alert_cfg.get("collapsed") else self.alert_window_expanded_h
+
+        top_y = margin
+        main_y = top_y + db_h + gap
+        alert_y = vh - margin - alert_h
+        main_h = max(220, alert_y - gap - main_y)
+        panel_w = max(700, vw - margin * 2)
+
+        dpg.configure_item("global_db_window", width=panel_w, height=db_h, pos=(margin, top_y))
+        dpg.configure_item("main_window", width=panel_w, height=main_h, pos=(margin, main_y))
+        dpg.configure_item("global_alert_window", width=panel_w, height=alert_h, pos=(margin, alert_y))
+        self.replay_tab.apply_responsive_layout()
 
     def on_viewport_resize(self, sender=None, app_data=None):
-        if not app_data:
-            return
-        vw, vh = app_data
-        if dpg.does_item_exist("global_db_window"):
-            dpg.configure_item("global_db_window", width=vw - 20, pos=(10, 10))
-        if dpg.does_item_exist("global_alert_window"):
-            dpg.configure_item("global_alert_window", width=vw - 20, pos=(10, vh - 250))
-        if dpg.does_item_exist("main_window"):
-            dpg.configure_item("main_window", width=vw - 20, height=vh - 420, pos=(10, 150))
-            self.replay_tab.apply_responsive_layout()
+        self.layout_windows()
 
     def on_tab_change(self, sender, app_data):
         if dpg.get_item_label(app_data):
@@ -41,17 +59,13 @@ class KBOIntegratedDPGApp:
 
         with dpg.window(
             tag="global_db_window",
-            label="global_db_window",
+            label="공통 DB 연결",
             width=self.default_viewport_w - 20,
             height=130,
             pos=(10, 10),
             no_resize=True,
             no_move=True,
-            no_title_bar=True,
-            no_collapse=True,
         ):
-            dpg.add_text("🧩 공통 DB 연결 패널", color=(120, 180, 255))
-            dpg.add_separator()
             with dpg.group(horizontal=True):
                 dpg.add_text("DSN")
                 dpg.add_input_text(tag="dsn_input", width=900, default_value=self.state.default_dsn)
@@ -75,17 +89,13 @@ class KBOIntegratedDPGApp:
 
         with dpg.window(
             tag="global_alert_window",
-            label="global_alert_window",
+            label="전역 알림",
             width=self.default_viewport_w - 20,
             height=240,
             pos=(10, self.default_viewport_h - 250),
             no_resize=True,
             no_move=True,
-            no_title_bar=True,
-            no_collapse=True,
         ):
-            dpg.add_text("🔔 전역 알림 패널", color=(120, 255, 160))
-            dpg.add_separator()
             dpg.add_input_text(tag="global_notification_text", multiline=True, readonly=True, width=-1, height=120)
             with dpg.group(horizontal=True):
                 dpg.add_button(label="최근 오류 다시 보기 (F8)", callback=lambda: self.state.show_recent_error())
@@ -108,8 +118,9 @@ class KBOIntegratedDPGApp:
         bind_korean_font(size=16)
         dpg.set_viewport_resize_callback(self.on_viewport_resize)
         dpg.show_viewport()
-        self.replay_tab.apply_responsive_layout()
+        self.layout_windows()
         while dpg.is_dearpygui_running():
+            self.layout_windows()
             self.collection_tab.message_pump()
             dpg.render_dearpygui_frame()
 

--- a/kbo_integrated_gui.py
+++ b/kbo_integrated_gui.py
@@ -31,10 +31,17 @@ class KBOIntegratedDPGApp:
         margin = 10
         gap = 10
 
-        db_cfg = dpg.get_item_configuration("global_db_window") if dpg.does_item_exist("global_db_window") else {}
-        alert_cfg = dpg.get_item_configuration("global_alert_window") if dpg.does_item_exist("global_alert_window") else {}
-        db_h = self.collapsed_h if db_cfg.get("collapsed") else self.db_window_expanded_h
-        alert_h = self.collapsed_h if alert_cfg.get("collapsed") else self.alert_window_expanded_h
+        def _window_height(tag: str, expanded_h: int) -> int:
+            if not dpg.does_item_exist(tag):
+                return expanded_h
+            cfg = dpg.get_item_configuration(tag)
+            state = dpg.get_item_state(tag)
+            rect_h = (state.get("rect_size") or (0, expanded_h))[1]
+            collapsed = bool(cfg.get("collapsed")) or rect_h <= (self.collapsed_h + 6)
+            return self.collapsed_h if collapsed else expanded_h
+
+        db_h = _window_height("global_db_window", self.db_window_expanded_h)
+        alert_h = _window_height("global_alert_window", self.alert_window_expanded_h)
 
         top_y = margin
         main_y = top_y + db_h + gap

--- a/kbo_integrated_gui.py
+++ b/kbo_integrated_gui.py
@@ -21,7 +21,15 @@ class KBOIntegratedDPGApp:
         self.default_viewport_h = 940
 
     def on_viewport_resize(self, sender=None, app_data=None):
+        if not app_data:
+            return
+        vw, vh = app_data
+        if dpg.does_item_exist("global_db_window"):
+            dpg.configure_item("global_db_window", width=vw - 20, pos=(10, 10))
+        if dpg.does_item_exist("global_alert_window"):
+            dpg.configure_item("global_alert_window", width=vw - 20, pos=(10, vh - 250))
         if dpg.does_item_exist("main_window"):
+            dpg.configure_item("main_window", width=vw - 20, height=vh - 420, pos=(10, 150))
             self.replay_tab.apply_responsive_layout()
 
     def on_tab_change(self, sender, app_data):
@@ -31,21 +39,46 @@ class KBOIntegratedDPGApp:
     def build(self):
         dpg.create_context()
 
-        with dpg.window(tag="main_window", label="KBO DB Replay QA", width=self.default_viewport_w - 40, height=self.default_viewport_h - 60):
+        with dpg.window(
+            tag="global_db_window",
+            label="공통 DB 연결",
+            width=self.default_viewport_w - 20,
+            height=130,
+            pos=(10, 10),
+            no_resize=True,
+            no_move=True,
+        ):
             dpg.add_text("공통 DB 연결", color=(120, 180, 255))
             with dpg.group(horizontal=True):
                 dpg.add_text("DSN")
                 dpg.add_input_text(tag="dsn_input", width=900, default_value=self.state.default_dsn)
                 dpg.add_button(label="DB 연결", callback=lambda: self.ingestion_tab.connect_db())
             dpg.add_text("DB 상태", tag="status_text")
-            dpg.add_input_text(tag="status_detail_text", multiline=True, readonly=True, width=-1, height=90)
-            dpg.add_separator()
+            dpg.add_input_text(tag="status_detail_text", multiline=True, readonly=True, width=-1, height=40)
 
+        with dpg.window(
+            tag="main_window",
+            label="KBO DB Replay QA",
+            width=self.default_viewport_w - 20,
+            height=self.default_viewport_h - 420,
+            pos=(10, 150),
+            no_resize=True,
+            no_move=True,
+        ):
             with dpg.tab_bar(tag="main_tab_bar", callback=self.on_tab_change):
                 self.collection_tab.build(parent="main_tab_bar")
                 self.ingestion_tab.build(parent="main_tab_bar")
                 self.replay_tab.build(parent="main_tab_bar")
-            dpg.add_separator()
+
+        with dpg.window(
+            tag="global_alert_window",
+            label="전역 알림",
+            width=self.default_viewport_w - 20,
+            height=240,
+            pos=(10, self.default_viewport_h - 250),
+            no_resize=True,
+            no_move=True,
+        ):
             dpg.add_text("전역 알림 패널", color=(120, 255, 160))
             dpg.add_input_text(tag="global_notification_text", multiline=True, readonly=True, width=-1, height=120)
             with dpg.group(horizontal=True):

--- a/kbo_integrated_gui.py
+++ b/kbo_integrated_gui.py
@@ -41,14 +41,17 @@ class KBOIntegratedDPGApp:
 
         with dpg.window(
             tag="global_db_window",
-            label="공통 DB 연결",
+            label="global_db_window",
             width=self.default_viewport_w - 20,
             height=130,
             pos=(10, 10),
             no_resize=True,
             no_move=True,
+            no_title_bar=True,
+            no_collapse=True,
         ):
-            dpg.add_text("공통 DB 연결", color=(120, 180, 255))
+            dpg.add_text("🧩 공통 DB 연결 패널", color=(120, 180, 255))
+            dpg.add_separator()
             with dpg.group(horizontal=True):
                 dpg.add_text("DSN")
                 dpg.add_input_text(tag="dsn_input", width=900, default_value=self.state.default_dsn)
@@ -72,14 +75,17 @@ class KBOIntegratedDPGApp:
 
         with dpg.window(
             tag="global_alert_window",
-            label="전역 알림",
+            label="global_alert_window",
             width=self.default_viewport_w - 20,
             height=240,
             pos=(10, self.default_viewport_h - 250),
             no_resize=True,
             no_move=True,
+            no_title_bar=True,
+            no_collapse=True,
         ):
-            dpg.add_text("전역 알림 패널", color=(120, 255, 160))
+            dpg.add_text("🔔 전역 알림 패널", color=(120, 255, 160))
+            dpg.add_separator()
             dpg.add_input_text(tag="global_notification_text", multiline=True, readonly=True, width=-1, height=120)
             with dpg.group(horizontal=True):
                 dpg.add_button(label="최근 오류 다시 보기 (F8)", callback=lambda: self.state.show_recent_error())

--- a/tabs/collection_tab.py
+++ b/tabs/collection_tab.py
@@ -35,6 +35,14 @@ class CollectionTab:
     def log(self, msg):
         self.msg_q.put(msg)
 
+    def _channel_from_message(self, message: str) -> str:
+        txt = str(message)
+        if "[오류]" in txt or "실패" in txt or "예외" in txt:
+            return "error"
+        if "[중지]" in txt or "없습니다" in txt or "유효하지" in txt:
+            return "warn"
+        return "info"
+
     def debug_log(self, debug_log_path, msg):
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         with open(debug_log_path, "a", encoding="utf-8") as f:
@@ -48,6 +56,7 @@ class CollectionTab:
                     tag, val = m
                     if tag == "progress":
                         dpg.configure_item(self._t("progress_bar"), default_value=float(val))
+                        self.state.set_status("info", "데이터 수집 진행", f"진행률: {int(float(val) * 100)}%", source="데이터 수집")
                     elif tag == "done":
                         for item in self.disable_items:
                             dpg.configure_item(item, enabled=True)
@@ -58,6 +67,8 @@ class CollectionTab:
                     prev = (prev + "\n" if prev else "") + str(m)
                     dpg.set_value(self._t("log"), prev)
                     dpg.set_y_scroll(self._t("log_window"), 1.0)
+                    channel = self._channel_from_message(str(m))
+                    self.state.set_status(channel, "데이터 수집 이벤트", str(m), source="데이터 수집")
         except queue.Empty:
             pass
 
@@ -249,6 +260,7 @@ class CollectionTab:
                 self.msg_q.put(("progress", 1.0))
         except Exception as e:
             self.log("[오류]\n" + "".join(traceback.format_exception(type(e), e, e.__traceback__)))
+            self.state.set_status("error", "데이터 수집 실패", "수집 중 예외가 발생했습니다.", debug_detail=traceback.format_exc(), source="데이터 수집")
         finally:
             if scr and getattr(scr, "driver", None):
                 try:
@@ -274,6 +286,7 @@ class CollectionTab:
                 ed = datetime.datetime.strptime(dpg.get_value(self._t("end_date")), "%Y-%m-%d").date()
                 if ed < sd:
                     self.log("종료일은 시작일보다 이전일 수 없습니다.")
+                    self.state.set_status("warn", "입력값 확인", "종료일은 시작일보다 이전일 수 없습니다.", source="데이터 수집")
                     return
             elif mode == "single":
                 sd = ed = datetime.datetime.strptime(dpg.get_value(self._t("single_date")), "%Y-%m-%d").date()
@@ -281,12 +294,14 @@ class CollectionTab:
                 year = int(dpg.get_value(self._t("season_year")))
                 if year < 2020:
                     self.log("시즌은 2020년부터 선택 가능합니다.")
+                    self.state.set_status("warn", "입력값 확인", "시즌은 2020년부터 선택 가능합니다.", source="데이터 수집")
                     return
                 sd = datetime.date(year, 1, 1)
                 ed = datetime.date(year, 12, 31)
                 season_year = year
         except ValueError:
             self.log("날짜 형식이 올바르지 않습니다.")
+            self.state.set_status("warn", "입력값 확인", "날짜 형식이 올바르지 않습니다.", source="데이터 수집")
             return
 
         os.makedirs(save_dir, exist_ok=True)
@@ -298,10 +313,12 @@ class CollectionTab:
         self.stop_flag.clear()
         self.worker = threading.Thread(target=self.run_scraper, args=(mode, sd, ed, save_dir, timeout, retry, season_year), daemon=True)
         self.worker.start()
+        self.state.set_status("info", "데이터 수집 시작", f"모드={mode}, 저장 경로={save_dir}", source="데이터 수집")
 
     def stop_scrape(self):
         self.stop_flag.set()
         self.log("중지 요청됨. 현재 작업이 완료될 때까지 기다려주세요.")
+        self.state.set_status("warn", "데이터 수집 중지 요청", "현재 작업이 완료된 뒤 중지됩니다.", source="데이터 수집")
 
     def open_save_dir_dialog(self):
         dpg.configure_item(self._t("save_dir_dialog"), show=True)

--- a/tabs/ingestion_tab.py
+++ b/tabs/ingestion_tab.py
@@ -101,17 +101,9 @@ class IngestionTab:
     def build(self, parent):
         with dpg.tab(label="데이터 적재", parent=parent):
             with dpg.group(horizontal=True):
-                dpg.add_text("DSN")
-                dpg.add_input_text(tag="dsn_input", width=900, default_value=self.state.default_dsn)
-                dpg.add_button(label="DB 연결", callback=lambda: self.connect_db())
-
-            with dpg.group(horizontal=True):
                 dpg.add_text("JSON 경로")
                 dpg.add_input_text(tag="json_data_dir_input", width=520, default_value=self.state.default_data_dir)
                 dpg.add_text("스키마")
                 dpg.add_input_text(tag="schema_path_input", width=260, default_value=self.state.default_schema_path)
                 dpg.add_button(label="스키마 생성", callback=lambda: self.create_schema())
                 dpg.add_button(label="JSON 적재", callback=lambda: self.ingest_json_to_db())
-
-            dpg.add_text("상태", tag="status_text")
-            dpg.add_input_text(tag="status_detail_text", multiline=True, readonly=True, width=-1, height=180)

--- a/tabs/ingestion_tab.py
+++ b/tabs/ingestion_tab.py
@@ -16,40 +16,39 @@ class IngestionTab:
 
     def connect_db(self):
         dsn = dpg.get_value("dsn_input").strip()
-        self.state.set_status("DB 연결 중...", "DSN 확인 및 DB 연결을 시도합니다.")
+        self.state.set_status("info", "DB 연결 중...", "DSN 확인 및 DB 연결을 시도합니다.", source="데이터 적재")
         try:
             self.state.conn = psycopg.connect(dsn)
             self.state.conn.autocommit = True
-            self.state.set_status("DB 연결 성공", "DB 연결 완료. 게임 목록을 불러옵니다.", append=True)
+            self.state.set_status("info", "DB 연결 성공", "DB 연결 완료. 게임 목록을 불러옵니다.", source="데이터 적재", append=True)
             self.load_games()
-            self.state.set_status("DB 연결 및 게임 목록 로드 완료", "연결/초기 로딩 단계 완료.", append=True)
+            self.state.set_status("info", "DB 연결 및 게임 목록 로드 완료", "연결/초기 로딩 단계 완료.", source="데이터 적재", append=True)
         except Exception as e:
-            self.state.set_status("DB 연결 실패", "사용자 메시지: DSN/네트워크/DB 상태를 확인하세요.", append=False)
-            self.state.set_status("DB 연결 실패", f"디버그 예외: {e}", append=True)
+            self.state.set_status("error", "DB 연결 실패", "DSN/네트워크/DB 상태를 확인하세요.", debug_detail=str(e), source="데이터 적재", append=False)
 
     def create_schema(self):
         if not self.state.conn:
-            self.state.set_status("스키마 생성 실패", "먼저 DB 연결을 진행하세요.")
+            self.state.set_status("warn", "스키마 생성 실패", "먼저 DB 연결을 진행하세요.", source="데이터 적재")
             return
         schema_path = Path(dpg.get_value("schema_path_input")).expanduser()
         if not schema_path.exists():
-            self.state.set_status("스키마 생성 실패", f"스키마 파일을 찾을 수 없습니다: {schema_path}")
+            self.state.set_status("warn", "스키마 생성 실패", f"스키마 파일을 찾을 수 없습니다: {schema_path}", source="데이터 적재")
             return
         try:
             with self.state.conn.cursor() as cur:
                 cur.execute(schema_path.read_text(encoding="utf-8"))
-            self.state.set_status("스키마 생성 완료", f"스키마 반영: {schema_path}", append=True)
+            self.state.set_status("info", "스키마 생성 완료", f"스키마 반영: {schema_path}", source="데이터 적재", append=True)
         except Exception as e:
-            self.state.set_status("스키마 생성 실패", str(e), append=True)
+            self.state.set_status("error", "스키마 생성 실패", "스키마 적용 중 오류가 발생했습니다.", debug_detail=str(e), source="데이터 적재", append=True)
 
     def ingest_json_to_db(self):
         if not self.state.conn:
-            self.state.set_status("적재 실패", "먼저 DB 연결을 진행하세요.")
+            self.state.set_status("warn", "적재 실패", "먼저 DB 연결을 진행하세요.", source="데이터 적재")
             return
 
         data_dir = Path(dpg.get_value("json_data_dir_input")).expanduser()
         if not data_dir.exists():
-            self.state.set_status("적재 실패", f"데이터 디렉터리를 찾을 수 없습니다: {data_dir}")
+            self.state.set_status("warn", "적재 실패", f"데이터 디렉터리를 찾을 수 없습니다: {data_dir}", source="데이터 적재")
             return
 
         loaded = 0
@@ -57,10 +56,10 @@ class IngestionTab:
             for json_path in sorted(data_dir.rglob("*.json")):
                 load_one_game(self.state.conn, json_path)
                 loaded += 1
-            self.state.set_status("적재 완료", f"JSON 적재 완료: {loaded}개 파일", append=True)
+            self.state.set_status("info", "적재 완료", f"JSON 적재 완료: {loaded}개 파일", source="데이터 적재", append=True)
             self.load_games()
         except Exception as e:
-            self.state.set_status("적재 실패", f"적재 중 오류: {e}", append=True)
+            self.state.set_status("error", "적재 실패", "적재 중 오류가 발생했습니다.", debug_detail=str(e), source="데이터 적재", append=True)
 
     def load_games(self):
         if not self.state.conn:
@@ -90,12 +89,14 @@ class IngestionTab:
         if labels:
             selected_game_id = self.state.games[0][0]
             self.state.set_status(
+                "info",
                 f"게임 목록 로드 완료 ({len(labels)}건)",
                 f"현재 선택 game_id={selected_game_id}",
+                source="데이터 적재",
                 append=True,
             )
         else:
-            self.state.set_status("게임 목록 로드 완료 (0건)", "표시 가능한 게임이 없습니다.", append=True)
+            self.state.set_status("warn", "게임 목록 로드 완료 (0건)", "표시 가능한 게임이 없습니다.", source="데이터 적재", append=True)
 
     def build(self, parent):
         with dpg.tab(label="데이터 적재", parent=parent):

--- a/tabs/replay_tab.py
+++ b/tabs/replay_tab.py
@@ -82,19 +82,21 @@ class ReplayTab:
 
     def load_selected_game(self):
         if not self.state.conn:
-            self.state.set_status("게임 로드 실패", "사용자 메시지: 먼저 DB 연결을 진행하세요.")
+            self.state.set_status("warn", "게임 로드 실패", "먼저 DB 연결을 진행하세요.", source="Replay")
             return
 
         sel = dpg.get_value("game_combo")
         hit = [g for g in self.state.games if g[1] == sel]
         if not hit:
-            self.state.set_status("게임 로드 실패", "사용자 메시지: 게임 선택 값이 유효하지 않습니다.")
+            self.state.set_status("warn", "게임 로드 실패", "게임 선택 값이 유효하지 않습니다.", source="Replay")
             return
 
         self.state.game_id = hit[0][0]
         self.state.set_status(
+            "info",
             f"게임 로드 중... (game_id={self.state.game_id})",
             f"선택 게임 로드 시작: game_id={self.state.game_id}",
+            source="Replay",
             append=False,
         )
         try:
@@ -103,7 +105,7 @@ class ReplayTab:
                 self.player_name_by_id = {row[0]: row[1] for row in cur.fetchall() if row[0]}
 
             self.events = self.fetch_events(self.state.game_id)
-            self.state.set_status("게임 로드 중...", f"이벤트 로드 완료: {len(self.events)}건", append=True)
+            self.state.set_status("info", "게임 로드 중...", f"이벤트 로드 완료: {len(self.events)}건", source="Replay", append=True)
 
             self.pitches = self.fetch_pitches(self.state.game_id)
             self.pitch_state_by_event = {}
@@ -115,7 +117,7 @@ class ReplayTab:
                     "balls": self.safe_int(p[10]),
                     "strikes": self.safe_int(p[11]),
                 }
-            self.state.set_status("게임 로드 중...", f"투구 로드 완료: {len(self.pitches)}건", append=True)
+            self.state.set_status("info", "게임 로드 중...", f"투구 로드 완료: {len(self.pitches)}건", source="Replay", append=True)
 
             self.pas = self.fetch_pas(self.state.game_id)
             self.pa_state_by_id = {}
@@ -127,10 +129,10 @@ class ReplayTab:
                     "start_seqno": self.safe_int(pa[12]),
                     "end_seqno": self.safe_int(pa[13]),
                 }
-            self.state.set_status("게임 로드 중...", f"타석 로드 완료: {len(self.pas)}건", append=True)
+            self.state.set_status("info", "게임 로드 중...", f"타석 로드 완료: {len(self.pas)}건", source="Replay", append=True)
 
             self.innings = self.fetch_innings(self.state.game_id)
-            self.state.set_status("게임 로드 중...", f"이닝 로드 완료: {len(self.innings)}건", append=True)
+            self.state.set_status("info", "게임 로드 중...", f"이닝 로드 완료: {len(self.innings)}건", source="Replay", append=True)
             self.derived_state_by_event = self.build_derived_state_map()
 
             self.event_idx = self.pitch_idx = self.pa_idx = self.inning_idx = 0
@@ -146,13 +148,14 @@ class ReplayTab:
             self.refresh_pitch_table(highlight_event_id=self.current_event_id())
             self.refresh_warning_panel()
             self.state.set_status(
+                "info",
                 f"게임 로드 완료 (game_id={self.state.game_id})",
                 "이벤트/투구/타석/이닝 데이터 로드 및 초기 렌더링이 완료되었습니다.",
+                source="Replay",
                 append=True,
             )
         except Exception as e:
-            self.state.set_status("게임 로드 실패", "사용자 메시지: 데이터를 불러오는 중 오류가 발생했습니다.", append=False)
-            self.state.set_status("게임 로드 실패", f"디버그 예외: {e}", append=True)
+            self.state.set_status("error", "게임 로드 실패", "데이터를 불러오는 중 오류가 발생했습니다.", debug_detail=str(e), source="Replay", append=False)
 
     def get_pa_event_columns(self):
         if self.pa_event_columns is not None:
@@ -406,7 +409,7 @@ class ReplayTab:
             "relay_text",
             f"진행률 {self.event_idx + 1} / {len(self.events)}\n이닝: {e[2]}회{half_txt}\n중계: {e[7] or '(텍스트 없음)'}",
         )
-        self.state.set_status(f"이벤트 포커스 | game_id={self.state.game_id}")
+        self.state.set_status("info", f"이벤트 포커스 | game_id={self.state.game_id}", source="Replay")
         self.is_syncing_event_slider = True
         dpg.set_value("event_slider", self.event_idx)
         dpg.set_value("event_jump_input", self.event_idx)
@@ -469,9 +472,9 @@ class ReplayTab:
             if dpg.does_item_exist(self.overlay_drawlist_tag):
                 dpg.delete_item(self.overlay_drawlist_tag, children_only=True)
                 dpg.draw_image(self.tex_tag, pmin=(0, 0), pmax=(self.tex_w, self.tex_h), parent=self.overlay_drawlist_tag, tag=self.background_draw_tag)
-            self.state.set_status(f"배경 이미지 로드 성공: {p}")
+            self.state.set_status("info", "배경 이미지 로드 성공", f"이미지 경로: {p}", source="Replay")
         except Exception as e:
-            self.state.set_status(f"배경 이미지 로드 실패: {e}")
+            self.state.set_status("error", "배경 이미지 로드 실패", "이미지를 적용하지 못했습니다.", debug_detail=str(e), source="Replay")
 
     def apply_responsive_layout(self):
         if dpg.does_item_exist("event_slider"):

--- a/tabs/shared_state.py
+++ b/tabs/shared_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import datetime as dt
 import json
 import os
 from pathlib import Path
@@ -15,7 +16,13 @@ class AppState:
     conn: Any = None
     games: list[tuple[Any, str]] = field(default_factory=list)
     game_id: Any = None
+
     status_logs: list[str] = field(default_factory=list)
+    notification_lines: list[str] = field(default_factory=list)
+    active_tab: str = "데이터 수집"
+    last_error_summary: str = ""
+    last_error_debug: str = ""
+    last_update_at: str = "-"
 
     default_dsn: str = ""
     default_image_path: str = "assets/stadium.png"
@@ -47,16 +54,85 @@ class AppState:
         state.default_schema_path = config.get("paths", {}).get("schema_path", "sql/schema.sql")
         return state
 
-    def set_status(self, summary: str, detail: str | None = None, append: bool = False) -> None:
+    def set_active_tab(self, tab_name: str) -> None:
+        self.active_tab = tab_name
+        if dpg.does_item_exist("global_status_current_tab"):
+            dpg.set_value("global_status_current_tab", f"현재 탭: {tab_name}")
+
+    def _status_color(self, channel: str) -> tuple[int, int, int]:
+        if channel == "error":
+            return (255, 110, 110)
+        if channel == "warn":
+            return (255, 195, 90)
+        return (120, 220, 140)
+
+    def _status_label(self, channel: str) -> str:
+        return {"info": "성공/진행", "warn": "경고", "error": "실패"}.get(channel, channel)
+
+    def _format_notification_line(self, channel: str, source: str, summary: str, user_detail: str | None) -> str:
+        timestamp = dt.datetime.now().strftime("%H:%M:%S")
+        detail_part = f" | {user_detail}" if user_detail else ""
+        return f"[{timestamp}] [{channel.upper()}] [{source}] {summary}{detail_part}"
+
+    def _refresh_notification_panel(self) -> None:
+        if dpg.does_item_exist("global_notification_text"):
+            dpg.set_value("global_notification_text", "\n".join(self.notification_lines[-300:]))
+
+    def _refresh_error_panel(self) -> None:
+        if dpg.does_item_exist("recent_error_summary"):
+            dpg.set_value("recent_error_summary", self.last_error_summary or "최근 오류 없음")
+        if dpg.does_item_exist("global_error_debug_text"):
+            dpg.set_value("global_error_debug_text", self.last_error_debug or "디버그 상세 없음")
+
+    def toggle_error_detail(self) -> None:
+        if not dpg.does_item_exist("error_detail_group"):
+            return
+        visible = dpg.is_item_shown("error_detail_group")
+        dpg.configure_item("error_detail_group", show=not visible)
+
+    def show_recent_error(self) -> None:
+        self._refresh_error_panel()
+        if dpg.does_item_exist("error_detail_group"):
+            dpg.configure_item("error_detail_group", show=True)
+
+    def set_status(
+        self,
+        channel: str,
+        summary: str,
+        user_detail: str | None = None,
+        *,
+        debug_detail: str | None = None,
+        source: str = "공통",
+        append: bool = True,
+    ) -> None:
+        self.last_update_at = dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        merged_detail = user_detail
+        if debug_detail:
+            merged_detail = f"{user_detail}\n[debug] {debug_detail}" if user_detail else f"[debug] {debug_detail}"
+
         if dpg.does_item_exist("status_text"):
             dpg.set_value("status_text", summary)
 
-        if detail is None or not dpg.does_item_exist("status_detail_text"):
-            return
+        if merged_detail is not None and dpg.does_item_exist("status_detail_text"):
+            if append:
+                self.status_logs.append(merged_detail)
+            else:
+                self.status_logs = [merged_detail]
+            dpg.set_value("status_detail_text", "\n".join(self.status_logs[-200:]))
 
-        if append:
-            self.status_logs.append(detail)
-        else:
-            self.status_logs = [detail]
+        notification = self._format_notification_line(channel, source, summary, user_detail)
+        self.notification_lines.append(notification)
+        self._refresh_notification_panel()
 
-        dpg.set_value("status_detail_text", "\n".join(self.status_logs))
+        if channel == "error":
+            self.last_error_summary = user_detail or summary
+            self.last_error_debug = debug_detail or user_detail or summary
+            self._refresh_error_panel()
+
+        if dpg.does_item_exist("global_status_recent_task"):
+            dpg.set_value("global_status_recent_task", f"최근 작업: {source} | {summary}")
+        if dpg.does_item_exist("global_status_result"):
+            dpg.set_value("global_status_result", f"상태: {self._status_label(channel)}")
+            dpg.configure_item("global_status_result", color=self._status_color(channel))
+        if dpg.does_item_exist("global_status_updated_at"):
+            dpg.set_value("global_status_updated_at", f"마지막 업데이트: {self.last_update_at}")


### PR DESCRIPTION
### Motivation

- Provide a single, consistent status/notification pipeline across tabs so progress, warnings and errors are uniformly surfaced to users and operators.
- Make error reporting more actionable by separating user-facing summaries from debug details and adding a quick way to reopen the most recent error without switching tabs.
- Surface tab context and recent task/result metadata persistently in the main window so overall app state is easier to monitor.

### Description

- Refactored `AppState` in `tabs/shared_state.py` to a channel-based API `set_status(channel, summary, user_detail=None, *, debug_detail=None, source=..., append=...)`, added notification accumulation, recent-error tracking fields (`last_error_summary`, `last_error_debug`) and UI-refresh helpers (`show_recent_error`, `toggle_error_detail`, `set_active_tab`).
- Added a global notification area, expandable debug detail group, bottom status indicators (`global_status_current_tab`, `global_status_recent_task`, `global_status_result`, `global_status_updated_at`) and an `F8` hotkey in `kbo_integrated_gui.py` to show recent errors and toggle debug details.
- Updated `tabs/ingestion_tab.py` and `tabs/replay_tab.py` to publish standardized `info`/`warn`/`error` events via the new `set_status` signature and to provide separate `user_detail` and `debug_detail` where appropriate.
- Extended `tabs/collection_tab.py` to forward progress and textual log events into the global notification stream (mapping messages to `info`/`warn`/`error`), report start/stop/progress events to `AppState`, and publish exception debug traces into the error channel.

### Testing

- Compiled the modified modules with `python -m py_compile kbo_integrated_gui.py tabs/shared_state.py tabs/collection_tab.py tabs/ingestion_tab.py tabs/replay_tab.py` which completed successfully.
- No additional automated tests were added; changes are limited to UI/status plumbing and were validated by static compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d058115ac08324b3d93871051e4731)